### PR TITLE
Mejorar accesibilidad del listado de posts

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -408,6 +408,7 @@ body {
     border-radius: 5px;
     box-shadow: rgba(39,44,49,0.06) 8px 14px 38px, rgba(39, 44, 49, 0.03) 1px 3px 8px;
     transition: all 0.5s ease;
+    position: relative;
 }
 
 .post-card:hover {
@@ -416,7 +417,7 @@ body {
     transform: translate3D(0, -1px, 0);
 }
 
-.post-card-image-link {
+.post-card-image-container {
     position: relative;
     display: block;
     overflow: hidden;
@@ -430,20 +431,15 @@ body {
     background-size: cover;
 }
 
-.post-card-content-link {
-    position: relative;
-    display: block;
+.post-card-preview {
     padding: 25px 25px 0;
-    color: var(--darkgrey);
-}
-
-.post-card-content-link:hover {
-    text-decoration: none;
 }
 
 .post-card-tags {
-    display: block;
     margin-bottom: 4px;
+}
+
+.post-card-tag {
     color: var(--midgrey);
     font-size: 1.2rem;
     line-height: 1.15em;
@@ -454,6 +450,22 @@ body {
 
 .post-card-title {
     margin-top: 0;
+}
+
+.post-card-title a {
+    color: var(--darkgrey);
+    text-decoration: none;
+}
+
+.post-card-title a:after {
+    position: absolute;
+    inset: 0;
+    content: '';
+    z-index: 1;
+}
+
+.post-card-meta {
+    z-index: 2;
 }
 
 .post-card-content {
@@ -499,7 +511,7 @@ The first (most recent) post in the list is styled to be bigger than the others 
         flex-direction: row;
     }
 
-    .home-template .post-feed .post-card:nth-child(6n+1):not(.no-image) .post-card-image-link {
+    .home-template .post-feed .post-card:nth-child(6n+1):not(.no-image) .post-card-image-container {
         position: relative;
         flex: 1 1 auto;
         border-radius: 5px 0 0 5px;
@@ -515,7 +527,7 @@ The first (most recent) post in the list is styled to be bigger than the others 
         flex: 0 1 357px;
     }
 
-    .home-template .post-feed .post-card:nth-child(6n+1):not(.no-image) h2 {
+    .home-template .post-feed .post-card:nth-child(6n+1):not(.no-image) .post-card-title {
         font-size: 2.6rem;
     }
 
@@ -524,7 +536,7 @@ The first (most recent) post in the list is styled to be bigger than the others 
         line-height: 1.55em;
     }
 
-    .home-template .post-feed .post-card:nth-child(6n+1):not(.no-image) .post-card-content-link {
+    .home-template .post-feed .post-card:nth-child(6n+1):not(.no-image) .post-card-preview {
         padding: 30px 40px 0;
     }
 
@@ -2094,4 +2106,14 @@ a.ss360-suggests__image-wrap img {
     margin: -50px auto;
     width: 100%;
     text-align: center
+}
+
+/* Accessibility */
+
+.sr-only {
+    display: block;
+    margin-right: -10000px;
+    width: 1px;
+    height: 1px;
+    overflow:hidden;
 }

--- a/index.hbs
+++ b/index.hbs
@@ -8,13 +8,13 @@ into the {body} of the default.hbs template --}}
 <header class="site-header outer {{#if @site.cover_image}}" style="background-image: url({{@site.cover_image}}){{else}}no-cover{{/if}}">
     <div class="inner">
         <div class="site-header-content">
-            <h1 class="site-title">
+            <p class="site-title">
                 {{#if @site.logo}}
                     <img class="site-logo" src="{{@site.logo}}" alt="{{@site.title}}" />
                 {{else}}
                     {{@site.title}}
                 {{/if}}
-            </h1>
+            </p>
             <p class="site-description">{{@site.description}}</p>
         </div>
         {{> "site-nav"}}
@@ -24,12 +24,11 @@ into the {body} of the default.hbs template --}}
 {{!-- The main content area --}}
 <main id="site-main" class="site-main outer" role="main">
     <div class="inner">
+        <h1 class="sr-only">Posts</h1>
         <div class="post-feed">
             {{#foreach posts}}
-
                 {{!-- The tag below includes the markup for each post - partials/post-card.hbs --}}
                 {{> "post-card"}}
-
             {{/foreach}}
         </div>
     </div>

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,29 +1,33 @@
 <article class="post-card {{post_class}}{{#unless feature_image}} no-image{{/unless}}">
     {{#if feature_image}}
-        <a class="post-card-image-link" href="{{url}}">
+        <div class="post-card-image-container" href="{{url}}">
             <div class="post-card-image" style="background-image: url({{feature_image}})"></div>
-        </a>
+        </div>
     {{/if}}
     <div class="post-card-content">
-        <a class="post-card-content-link" href="{{url}}">
+        <div class="post-card-preview">
             <header class="post-card-header">
                 {{#if primary_tag}}
-                    <span class="post-card-tags">{{primary_tag.name}}</span>
+                    <div class="post-card-tags">
+                        <span class="sr-only">Tags: </span>
+                        <span class="post-card-tag">{{primary_tag.name}}</span>
+                    </div>
                 {{/if}}
-                <h2 class="post-card-title">{{title}}</h2>
+                <h2 class="post-card-title"><a href="{{url}}">{{title}}</a></h2>
             </header>
             <section class="post-card-excerpt">
                 <p>{{excerpt words="33"}}</p>
             </section>
-        </a>
+        </div>
         {{#primary_author}}
         <footer class="post-card-meta">
+            <span class="sr-only">Author: </span>
             {{#if profile_image}}
                 <img class="author-profile-image" src="{{profile_image}}" alt="{{name}}" />
             {{else}}
                 <img class="author-profile-image" src="{{asset "logo-circulizable-transparente-1.png"}} alt="{{name}}" />
             {{/if}}
-            <span class="post-card-author"><a href="{{url}}">{{name}}</a></span>
+            <a class="post-card-author" href="{{url}}">{{name}}</a>
         </footer>
         {{/primary_author}}
     </div>


### PR DESCRIPTION
* Agregar títulos y labels para screen readers.
* Dejar sólo el título de los posts como link, manteniendo el área clickeable de la card.

### Antes
https://user-images.githubusercontent.com/46203110/124484683-11db3e00-dd82-11eb-9ca4-3163cf4a3b20.mp4

### Después
https://user-images.githubusercontent.com/46203110/124484686-13a50180-dd82-11eb-8a16-713bcbc99c51.mp4
